### PR TITLE
Feat: bump version 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-adapter"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Eason Chai <hackerchai.com@gmail.com>","Cheng JIANG <jiang.cheng@vip.163.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage="https://github.com/casbin-rs/sqlx-adapter"
 readme="README.md"
 
 [dependencies]
-casbin = { version = "0.7.1", default-features = false }
+casbin = { version = "0.8.1", default-features = false, features = ["incremental"] }
 sqlx = {version = "0.3.5", default-features = false, features = [ "macros" ]}
 async-trait = "0.1.30"
 dotenv = { version = "0.15.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Based on [Sqlx](https://github.com/launchbadge/sqlx), The current supported data
 Add it to `Cargo.toml`
 
 ```rust
-casbin = { version = "0.7.1", default-features = false }
 sqlx-adapter = { version = "0.2.3", features = ["postgres"] }
 async-std = "1.5.0"
 ```
@@ -135,8 +134,8 @@ async-std = "1.5.0"
 ## Example
 
 ```rust
-use casbin::prelude::*;
-use casbin::Result;
+use sqlx_adapter::casbin::prelude::*;
+use sqlx_adapter::casbin::Result;
 use sqlx_adapter::SqlxAdapter;
 
 #[async_std::main]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Based on [Sqlx](https://github.com/launchbadge/sqlx), The current supported data
 Add it to `Cargo.toml`
 
 ```rust
-sqlx-adapter = { version = "0.2.3", features = ["postgres"] }
+sqlx-adapter = { version = "0.2.4", features = ["postgres"] }
 async-std = "1.5.0"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,7 @@ mod models;
 
 mod actions;
 
+pub use casbin;
+
 pub use adapter::SqlxAdapter;
 pub use error::Error;


### PR DESCRIPTION
1. update casbin & re-export casbin