### PR TITLE
Update definition of Filter<'a>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage= "https://github.com/casbin-rs/sqlx-adapter"
 readme= "README.md"
 
 [dependencies]
-casbin = { version = "1.1.0", default-features = false, features = ["incremental"] }
+casbin = { version = "1.1.2", default-features = false, features = ["incremental"] }
 sqlx = {version = "0.3.5", default-features = false, features = [ "macros" ]}
 async-trait = "0.1.36"
 dotenv = { version = "0.15.0", default-features = false }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -87,10 +87,10 @@ impl<'a> SqlxAdapter {
         None
     }
 
-    pub(crate) fn load_filtered_policy_line(
+    pub(crate) fn load_filtered_policy_line<'f>(
         &self,
         casbin_rule: &CasbinRule,
-        f: &Filter,
+        f: &Filter<'f>,
     ) -> Option<Vec<String>> {
         if let Some(sec) = casbin_rule.ptype.chars().next() {
             if let Some(policy) = self.normalize_policy(casbin_rule) {
@@ -168,7 +168,7 @@ impl Adapter for SqlxAdapter {
         Ok(())
     }
 
-    async fn load_filtered_policy(&mut self, m: &mut dyn Model, f: Filter) -> Result<()> {
+    async fn load_filtered_policy<'a>(&mut self, m: &mut dyn Model, f: Filter<'a>) -> Result<()> {
         let rules = adapter::load_policy(&self.pool).await?;
 
         for casbin_rule in &rules {


### PR DESCRIPTION
PR https://github.com/casbin/casbin-rs/pull/196 in Casbin changed the definition of the `Filter` struct to allow for filtering according to values created at runtime (as opposed to compile time like it was before).

This PR fixes compatibility with Casbin >=v1.1.2