### PR TITLE
Fix adapter::remove_filtered_policy method

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -89,7 +89,7 @@ pub async fn new(conn: &ConnectionPool) -> Result<MySqlQueryResult> {
 
 #[cfg(feature = "postgres")]
 pub async fn remove_policy(conn: &ConnectionPool, pt: &str, rule: Vec<String>) -> Result<bool> {
-    let rule = normalize_casbin_rule(rule, 0);
+    let rule = normalize_casbin_rule(rule);
     sqlx::query!(
         "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
@@ -115,7 +115,7 @@ pub async fn remove_policy(conn: &ConnectionPool, pt: &str, rule: Vec<String>) -
 
 #[cfg(feature = "sqlite")]
 pub async fn remove_policy(conn: &ConnectionPool, pt: &str, rule: Vec<String>) -> Result<bool> {
-    let rule = normalize_casbin_rule(rule, 0);
+    let rule = normalize_casbin_rule(rule);
     sqlx::query!(
         "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
@@ -141,7 +141,7 @@ pub async fn remove_policy(conn: &ConnectionPool, pt: &str, rule: Vec<String>) -
 
 #[cfg(feature = "mysql")]
 pub async fn remove_policy(conn: &ConnectionPool, pt: &str, rule: Vec<String>) -> Result<bool> {
-    let rule = normalize_casbin_rule(rule, 0);
+    let rule = normalize_casbin_rule(rule);
     sqlx::query!(
         "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
@@ -176,7 +176,7 @@ pub async fn remove_policies(
         .await
         .map_err(|err| CasbinError::from(AdapterError(Box::new(Error::SqlxError(err)))))?;
     for rule in rules {
-        let rule = normalize_casbin_rule(rule, 0);
+        let rule = normalize_casbin_rule(rule);
         sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
@@ -223,7 +223,7 @@ pub async fn remove_policies(
         .await
         .map_err(|err| CasbinError::from(AdapterError(Box::new(Error::SqlxError(err)))))?;
     for rule in rules {
-        let rule = normalize_casbin_rule(rule, 0);
+        let rule = normalize_casbin_rule(rule);
         sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
@@ -270,7 +270,7 @@ pub async fn remove_policies(
         .await
         .map_err(|err| CasbinError::from(AdapterError(Box::new(Error::SqlxError(err)))))?;
     for rule in rules {
-        let rule = normalize_casbin_rule(rule, 0);
+        let rule = normalize_casbin_rule(rule);
         sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
@@ -313,7 +313,7 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values, field_index);
+    let field_values = normalize_casbin_rule(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
@@ -408,7 +408,7 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values, field_index);
+    let field_values = normalize_casbin_rule(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
@@ -503,7 +503,7 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values, field_index);
+    let field_values = normalize_casbin_rule(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
@@ -1067,7 +1067,7 @@ pub(crate) async fn clear_policy(conn: &ConnectionPool) -> Result<()> {
     Ok(())
 }
 
-fn normalize_casbin_rule(mut rule: Vec<String>, field_index: usize) -> Vec<String> {
-    rule.resize(6 - field_index, String::from(""));
+fn normalize_casbin_rule(mut rule: Vec<String>) -> Vec<String> {
+    rule.resize(6, String::new());
     rule
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -546,7 +546,8 @@ mod tests {
 
         assert!(adapter
             .remove_filtered_policy("", "g", 0, to_owned(vec!["alice", "data2_admin"]))
-            .await.unwrap());
+            .await
+            .unwrap());
 
         assert!(adapter
             .add_policy(

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -251,7 +251,7 @@ impl Adapter for SqlxAdapter {
         field_index: usize,
         field_values: Vec<String>,
     ) -> Result<bool> {
-        if field_index <= 5 && !field_values.is_empty() && field_values.len() >= 6 - field_index {
+        if field_index <= 5 && !field_values.is_empty() && field_values.len() > field_index {
             adapter::remove_filtered_policy(&self.pool, pt, field_index, field_values).await
         } else {
             Ok(false)
@@ -427,7 +427,7 @@ mod tests {
         assert!(adapter
             .remove_policy("", "p", to_owned(vec!["alice", "data1", "read"]))
             .await
-            .is_ok());
+            .unwrap());
         assert!(adapter
             .remove_policy("", "p", to_owned(vec!["bob", "data2", "write"]))
             .await
@@ -546,8 +546,7 @@ mod tests {
 
         assert!(adapter
             .remove_filtered_policy("", "g", 0, to_owned(vec!["alice", "data2_admin"]))
-            .await
-            .is_ok());
+            .await.unwrap());
 
         assert!(adapter
             .add_policy(

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 use sqlx::FromRow;
 
+#[allow(dead_code)]
 #[cfg(any(feature = "postgres", feature = "mysql"))]
 #[derive(Debug, FromRow)]
 pub(crate) struct CasbinRule {


### PR DESCRIPTION
Change be reduced to: 

 - `adapter::remove_filtered_policy` checks if `field_index` is not out of bounds. Before it was forcing rule to be at least 6 elements.
 - `normalize_casbin_rule` normalizes rule to have 6 elements. Before, it would truncate/resize rule to `6 - field_index` elements. I believe this would actually result in index of bound error.
 - Tests now expose behavior I talked about in #66 

Example of index out of bound:

    let boxed_query = if field_index == 5 {
        Box::new(sqlx::query!(
            "DELETE FROM casbin_rule WHERE
                    ptype = $1 AND
                    (v5 is NULL OR v5 = $2)",
            pt.to_string(),
            field_values[5]
        ))
    } 

If this code path is taken right now, it will result in error becase `field_values` would be truncated to 1 element (`6 - 5`)


Closes #66 