### PR TITLE
ci: add test for multiple os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,11 @@ on:
 jobs:
   build:
     name: Auto Build CI
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: casbin_rs
-          POSTGRES_PASSWORD: casbin_rs
-          POSTGRES_DB: casbin
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      mysql:
-        image: mariadb
-        env:
-          MYSQL_DATABASE: casbin
-          MYSQL_USER: casbin_rs
-          MYSQL_PASSWORD: casbin_rs
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        rust: [ stable, beta, nightly ]
 
     steps:
       - name: Checkout Repository
@@ -41,19 +23,70 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
           override: true
 
-      - name: Install PostgreSQL & MySQL & SQLite Dependencies
-        run: sudo apt-get install libpq-dev postgresql-client mysql-client libmysqlclient-dev libsqlite3-dev sqlite3
+      - name: Setup PostgreSQL & MySQL & SQLite (for ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev postgresql libmysqlclient-dev mysql-client libsqlite3-dev sqlite3
+          echo "host    all             all             127.0.0.1/32            md5" > sudo tee -a /etc/postgresql/10/main/pg_hba.conf
+          sudo service postgresql restart && sleep 3
+          sudo -u postgres createuser casbin_rs
+          sudo -u postgres createdb casbin
+          sudo -u postgres psql -c "alter user casbin_rs with encrypted password 'casbin_rs'; grant all privileges on database casbin to casbin_rs;"
+          sudo service postgresql restart && sleep 3
+          sudo systemctl start mysql.service
+          mysql -e "create user 'casbin_rs'@'localhost' identified by 'casbin_rs'; create database casbin; grant all on \`casbin\`.* to 'casbin_rs'@'localhost';" -uroot -proot
+
+      - name: Setup PostgreSQL & MySQL & SQLite (for macOS)
+        if: matrix.os == 'macOS-latest'
+        run: |
+          brew update
+          brew install mariadb@10.5 sqlite
+          pg_ctl -D /usr/local/var/postgres start
+          sleep 3
+          createuser casbin_rs
+          createdb casbin
+          psql postgres -c "alter user casbin_rs with encrypted password 'casbin_rs'; grant all privileges on database casbin to casbin_rs;"
+          echo "/usr/local/opt/mariadb@10.5/bin" >> $GITHUB_PATH
+          /usr/local/opt/mariadb@10.5/bin/mysql_install_db
+          /usr/local/opt/mariadb@10.5/bin/mysql.server start
+          sleep 3
+          /usr/local/opt/mariadb@10.5/bin/mysql -e "create user 'casbin_rs'@'localhost' identified by 'casbin_rs'; create database casbin; grant all on \`casbin\`.* to 'casbin_rs'@'localhost';" -urunner
+          echo "MYSQLCLIENT_LIB_DIR=/usr/local/opt/mariadb@10.5/lib" >> $GITHUB_ENV
+
+      - name: Setup PostgreSQL & MySQL & SQLite (for windows)
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          choco install postgresql11 --force --params '/Password:root'
+          choco install mysql sqlite
+          "C:\Program Files\PostgreSQL\11\bin\createuser" casbin_rs
+          "C:\Program Files\PostgreSQL\11\bin\createdb" casbin
+          "C:\Program Files\PostgreSQL\11\bin\psql" -c "alter user casbin_rs with encrypted password 'casbin_rs'; grant all privileges on database casbin to casbin_rs;"
+          "C:\tools\mysql\current\bin\mysql" -e "create user 'casbin_rs'@'localhost' identified by 'casbin_rs'; create database casbin; grant all on `casbin`.* to 'casbin_rs'@'localhost';" -uroot
+          cd /D C:\ProgramData\chocolatey\lib\SQLite\tools
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          lib /machine:x64 /def:sqlite3.def /out:sqlite3.lib
+
+      - name: Set environment variables (for windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "C:\Program Files\PostgreSQL\11\bin" >> $GITHUB_PATH
+          echo "PQ_LIB_DIR=C:\Program Files\PostgreSQL\11\lib" >> $GITHUB_ENV
+          echo "MYSQLCLIENT_LIB_DIR=C:\tools\mysql\current\lib" >> $GITHUB_ENV
+          echo "SQLITE3_LIB_DIR=C:\ProgramData\chocolatey\lib\SQLite\tools" >> $GITHUB_ENV
 
       - name: Create SQLite DB
         run: |
           touch casbin.db
 
       - name: Create PostgresSQL Table
-        run: psql postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin -c "CREATE TABLE IF NOT EXISTS casbin_rule (
+        run: psql -c "CREATE TABLE IF NOT EXISTS casbin_rule (
           id SERIAL PRIMARY KEY,
           ptype VARCHAR NOT NULL,
           v0 VARCHAR NOT NULL,
@@ -63,11 +96,11 @@ jobs:
           v4 VARCHAR NOT NULL,
           v5 VARCHAR NOT NULL,
           CONSTRAINT unique_key_sqlx_adapter UNIQUE(ptype, v0, v1, v2, v3, v4, v5)
-          );"
+          );" postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
 
       - name: Create MySQL Table
         run: |
-          mysql -ucasbin_rs -pcasbin_rs --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -e "USE casbin; CREATE TABLE IF NOT EXISTS casbin_rule (
+          mysql -ucasbin_rs -pcasbin_rs -e "USE casbin; CREATE TABLE IF NOT EXISTS casbin_rule (
             id INT NOT NULL AUTO_INCREMENT,
             ptype VARCHAR(12) NOT NULL,
             v0 VARCHAR(128) NOT NULL,
@@ -104,7 +137,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-async-std-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-async-std-native-tls
@@ -112,7 +145,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-async-std-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-async-std-rustls
@@ -121,7 +154,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-tokio-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-tokio-native-tls
@@ -129,7 +162,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-tokio-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-tokio-rustls
@@ -138,7 +171,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-actix-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-actix-native-tls
@@ -146,7 +179,7 @@ jobs:
       - name: Cargo Test For PostgreSQL,runtime-actix-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin
+          DATABASE_URL: postgres://casbin_rs:casbin_rs@localhost:5432/casbin
         with:
           command: test
           args: --no-default-features --features postgres,runtime-actix-rustls
@@ -156,7 +189,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-async-std-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-async-std-native-tls
@@ -164,7 +197,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-async-std-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-async-std-rustls
@@ -173,7 +206,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-tokio-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-tokio-native-tls
@@ -181,7 +214,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-tokio-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-tokio-rustls
@@ -190,7 +223,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-actix-native-tls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-actix-native-tls
@@ -198,7 +231,7 @@ jobs:
       - name: Cargo Test For MySQL,runtime-actix-rustls
         uses: actions-rs/cargo@v1
         env:
-          DATABASE_URL: mysql://casbin_rs:casbin_rs@127.0.0.1:${{ job.services.mysql.ports[3306] }}/casbin
+          DATABASE_URL: mysql://casbin_rs:casbin_rs@localhost:3306/casbin
         with:
           command: test
           args: --no-default-features --features mysql,runtime-actix-rustls

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -300,14 +300,14 @@ mod tests {
         let adapter = {
             #[cfg(feature = "postgres")]
             {
-                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin", 8)
+                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@localhost:5432/casbin", 8)
                     .await
                     .unwrap()
             }
 
             #[cfg(feature = "mysql")]
             {
-                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@127.0.0.1:3306/casbin", 8)
+                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@localhost:3306/casbin", 8)
                     .await
                     .unwrap()
             }
@@ -347,7 +347,7 @@ mod tests {
             {
                 PgPoolOptions::new()
                     .max_connections(8)
-                    .connect("postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin")
+                    .connect("postgres://casbin_rs:casbin_rs@localhost:5432/casbin")
                     .await
                     .unwrap()
             }
@@ -356,7 +356,7 @@ mod tests {
             {
                 MySqlPoolOptions::new()
                     .max_connections(8)
-                    .connect("mysql://casbin_rs:casbin_rs@127.0.0.1:3306/casbin")
+                    .connect("mysql://casbin_rs:casbin_rs@localhost:3306/casbin")
                     .await
                     .unwrap()
             }
@@ -404,14 +404,14 @@ mod tests {
         let mut adapter = {
             #[cfg(feature = "postgres")]
             {
-                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@127.0.0.1:5432/casbin", 8)
+                SqlxAdapter::new("postgres://casbin_rs:casbin_rs@localhost:5432/casbin", 8)
                     .await
                     .unwrap()
             }
 
             #[cfg(feature = "mysql")]
             {
-                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@127.0.0.1:3306/casbin", 8)
+                SqlxAdapter::new("mysql://casbin_rs:casbin_rs@localhost:3306/casbin", 8)
                     .await
                     .unwrap()
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 use sqlx::FromRow;
 
+#[allow(dead_code)]
 #[cfg(any(feature = "postgres", feature = "mysql"))]
 #[derive(Debug, FromRow)]
 pub(crate) struct CasbinRule {

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,7 @@ pub(crate) struct CasbinRule {
     pub v5: String,
 }
 
+#[allow(dead_code)]
 #[cfg(feature = "sqlite")]
 #[derive(Debug, FromRow)]
 pub(crate) struct CasbinRule {


### PR DESCRIPTION
Test project on multiple operating systems via matrix.

ref: https://github.com/casbin/casbin-rs/issues/234
credit to: https://github.com/diesel-rs/diesel/blob/0c6219f5bd9641eea09c6fa7dca4995aefda30a0/.github/workflows/ci.yml

Note: replace `127.0.0.1` with `localhost` in `DATABASE_URL` as a workaround for this this issue: https://github.com/launchbadge/sqlx/issues/846
otherwise, build with feature `runtime-xxx-rustls` would fail with errors like:
```bash
error: error occurred while attempting to establish a TLS connection: InvalidDNSNameError
Error:   --> src/actions.rs:29:5
   |
29 | /     sqlx::query!(
30 | |         "CREATE TABLE IF NOT EXISTS casbin_rule (
31 | |                     id SERIAL PRIMARY KEY,
32 | |                     ptype VARCHAR NOT NULL,
...  |
41 | |         "
42 | |     )
   | |_____^
   |
   = note: this error originates in the macro `$crate::sqlx_macros::expand_query` (in Nightly builds, run with -Z macro-backtrace for more info)
```