### PR TITLE
fix: delete_user() does not remove grouping policy (#64)

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,42 +1,9 @@
 {
   "db": "PostgreSQL",
-  "0ee2b869a545c67051c3409d444bc853ca03a55b834f9823e0c7675556122317": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v2 is NULL OR v2 = $2) AND\n                    (v3 is NULL OR v3 = $3) AND\n                    (v4 is NULL OR v4 = $4) AND\n                    (v5 is NULL OR v5 = $5)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "17e78c432dbab089fa0a918dfdc2d5dae43d8354cc35d2cb5450b3e8a92ba9ec": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v1 is NULL OR v1 = $2) AND\n                    (v2 is NULL OR v2 = $3) AND\n                    (v3 is NULL OR v3 = $4) AND\n                    (v4 is NULL OR v4 = $5) AND\n                    (v5 is NULL OR v5 = $6)",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text"
-        ]
-      },
-      "nullable": []
-    }
-  },
   "1cabd2f674da323da9e0da724d3bcfe5f968b31500e8c8cf97fe16814bc04164": {
-    "query": "INSERT INTO casbin_rule ( ptype, v0, v1, v2, v3, v4, v5 )\n                 VALUES ( $1, $2, $3, $4, $5, $6, $7 )",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Varchar",
@@ -47,24 +14,39 @@
           "Varchar",
           "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "INSERT INTO casbin_rule ( ptype, v0, v1, v2, v3, v4, v5 )\n                 VALUES ( $1, $2, $3, $4, $5, $6, $7 )"
+  },
+  "1f299262f01a2c9d2ee94079a12766573c91b2775a086c65bc9a5fdc91300bb0": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Varchar",
+          "Varchar",
+          "Varchar"
+        ]
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v3 is NULL OR v3 = COALESCE($2,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($3,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($4,v5))"
   },
   "24876462291b90324dfe3682e9f36247a328db780a48da47c9402e1d3ebd80c9": {
-    "query": "DELETE FROM casbin_rule",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": []
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule"
   },
   "2872b56bbc5bed96b1a303bf9cf44610fb79a1b9330730c65953f0c1b88c2a53": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    v0 = $2 AND\n                    v1 = $3 AND\n                    v2 = $4 AND\n                    v3 = $5 AND\n                    v4 = $6 AND\n                    v5 = $7",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
@@ -75,58 +57,54 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    v0 = $2 AND\n                    v1 = $3 AND\n                    v2 = $4 AND\n                    v3 = $5 AND\n                    v4 = $6 AND\n                    v5 = $7"
   },
   "3022cb733970ae5836ab3891367b209a7e1f0974242ecd0f55e5b0098152bad5": {
-    "query": "SELECT * FROM casbin_rule",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Int4"
         },
         {
-          "ordinal": 1,
           "name": "ptype",
+          "ordinal": 1,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 2,
           "name": "v0",
+          "ordinal": 2,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 3,
           "name": "v1",
+          "ordinal": 3,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 4,
           "name": "v2",
+          "ordinal": 4,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 5,
           "name": "v3",
+          "ordinal": 5,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 6,
           "name": "v4",
+          "ordinal": 6,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 7,
           "name": "v5",
+          "ordinal": 7,
           "type_info": "Varchar"
         }
       ],
-      "parameters": {
-        "Left": []
-      },
       "nullable": [
         false,
         false,
@@ -136,123 +114,154 @@
         false,
         false,
         false
-      ]
-    }
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "SELECT * FROM casbin_rule"
   },
   "438ee38e669be96e562d09d3bc5806b4c78b7aa2a9609c4eccb941c7dff7b107": {
-    "query": "CREATE TABLE IF NOT EXISTS casbin_rule (\n                    id SERIAL PRIMARY KEY,\n                    ptype VARCHAR NOT NULL,\n                    v0 VARCHAR NOT NULL,\n                    v1 VARCHAR NOT NULL,\n                    v2 VARCHAR NOT NULL,\n                    v3 VARCHAR NOT NULL,\n                    v4 VARCHAR NOT NULL,\n                    v5 VARCHAR NOT NULL,\n                    CONSTRAINT unique_key_sqlx_adapter UNIQUE(ptype, v0, v1, v2, v3, v4, v5)\n                    );\n        ",
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": []
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "CREATE TABLE IF NOT EXISTS casbin_rule (\n                    id SERIAL PRIMARY KEY,\n                    ptype VARCHAR NOT NULL,\n                    v0 VARCHAR NOT NULL,\n                    v1 VARCHAR NOT NULL,\n                    v2 VARCHAR NOT NULL,\n                    v3 VARCHAR NOT NULL,\n                    v4 VARCHAR NOT NULL,\n                    v5 VARCHAR NOT NULL,\n                    CONSTRAINT unique_key_sqlx_adapter UNIQUE(ptype, v0, v1, v2, v3, v4, v5)\n                    );\n        "
   },
-  "4904dd0b33bc73cd01c6330005e08d6e5290c894704a9802b8e597bdec4b2037": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v5 is NULL OR v5 = $2)",
+  "4acfe0086a593b08177791bb3b47cb75a999041a3eb6a8f8177bebfa3c30d56f": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
-          "Text"
+          "Varchar",
+          "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v4 is NULL OR v4 = COALESCE($2,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($3,v5))"
   },
-  "607b617f24e2032cf89b9550130a5358d8263e92c789d9f6c2f47b235b5b5903": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v3 is NULL OR v3 = $2) AND\n                    (v4 is NULL OR v4 = $3) AND\n                    (v5 is NULL OR v5 = $4)",
+  "4e7b82d256f7298564f46af6a45b89853785c32a5f83cb0b25609329c760428a": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
-          "Text",
-          "Text",
-          "Text"
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v1 is NULL OR v1 = COALESCE($2,v1)) AND\n                    (v2 is NULL OR v2 = COALESCE($3,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($4,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($5,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($6,v5))"
   },
-  "66c31e9d49e4aa3e01670e816a91b0e2926124b29ba66d2f995efb9957f5496f": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v0 is NULL OR v0 = $2) AND\n                    (v1 is NULL OR v1 = $3) AND\n                    (v2 is NULL OR v2 = $4) AND\n                    (v3 is NULL OR v3 = $5) AND\n                    (v4 is NULL OR v4 = $6) AND\n                    (v5 is NULL OR v5 = $7)",
+  "f130c22d14ee2a99b9220ac1a45226ba97993ede9988a4c57d58bd066500a119": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text"
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v0 is NULL OR v0 = COALESCE($2,v0)) AND\n                    (v1 is NULL OR v1 = COALESCE($3,v1)) AND\n                    (v2 is NULL OR v2 = COALESCE($4,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($5,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($6,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($7,v5))"
   },
-  "b91e273693cfaead6884d42e906ead1a1de7bbc4019a6e151b2e3bef84aa4889": {
-    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v4 is NULL OR v4 = $2) AND\n                    (v5 is NULL OR v5 = $3)",
+  "f8611a862ed1d3b982e8aa5ccab21e00c42a3fad8082cf15c2af88cd8388f41b": {
     "describe": {
       "columns": [],
+      "nullable": [],
       "parameters": {
         "Left": [
           "Text",
-          "Text",
-          "Text"
+          "Varchar",
+          "Varchar",
+          "Varchar",
+          "Varchar"
         ]
-      },
-      "nullable": []
-    }
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v2 is NULL OR v2 = COALESCE($2,v2)) AND\n                    (v3 is NULL OR v3 = COALESCE($3,v3)) AND\n                    (v4 is NULL OR v4 = COALESCE($4,v4)) AND\n                    (v5 is NULL OR v5 = COALESCE($5,v5))"
+  },
+  "fa51ae7af271fc17c848694fbf1b37d46c5a2f4202e1b8dce1f66a65069beb0b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Varchar"
+        ]
+      }
+    },
+    "query": "DELETE FROM casbin_rule WHERE\n                    ptype = $1 AND\n                    (v5 is NULL OR v5 = COALESCE($2,v5))"
   },
   "fb7ce69e70b345d2cf0ca017523c1b90b67b053add3d4cffb8d579bfc8f08345": {
-    "query": "SELECT * from  casbin_rule WHERE (\n            ptype LIKE 'g%' AND v0 LIKE $1 AND v1 LIKE $2 AND v2 LIKE $3 AND v3 LIKE $4 AND v4 LIKE $5 AND v5 LIKE $6 )\n        OR (\n            ptype LIKE 'p%' AND v0 LIKE $7 AND v1 LIKE $8 AND v2 LIKE $9 AND v3 LIKE $10 AND v4 LIKE $11 AND v5 LIKE $12 );\n            ",
     "describe": {
       "columns": [
         {
-          "ordinal": 0,
           "name": "id",
+          "ordinal": 0,
           "type_info": "Int4"
         },
         {
-          "ordinal": 1,
           "name": "ptype",
+          "ordinal": 1,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 2,
           "name": "v0",
+          "ordinal": 2,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 3,
           "name": "v1",
+          "ordinal": 3,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 4,
           "name": "v2",
+          "ordinal": 4,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 5,
           "name": "v3",
+          "ordinal": 5,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 6,
           "name": "v4",
+          "ordinal": 6,
           "type_info": "Varchar"
         },
         {
-          "ordinal": 7,
           "name": "v5",
+          "ordinal": 7,
           "type_info": "Varchar"
         }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
       ],
       "parameters": {
         "Left": [
@@ -269,17 +278,8 @@
           "Text",
           "Text"
         ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
+      }
+    },
+    "query": "SELECT * from  casbin_rule WHERE (\n            ptype LIKE 'g%' AND v0 LIKE $1 AND v1 LIKE $2 AND v2 LIKE $3 AND v3 LIKE $4 AND v4 LIKE $5 AND v5 LIKE $6 )\n        OR (\n            ptype LIKE 'p%' AND v0 LIKE $7 AND v1 LIKE $8 AND v2 LIKE $9 AND v3 LIKE $10 AND v4 LIKE $11 AND v5 LIKE $12 );\n            "
   }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -313,77 +313,77 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values);
+    let field_values = normalize_casbin_rule_option(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v5 is NULL OR v5 = $2)",
+                    (v5 is NULL OR v5 = COALESCE($2,v5))",
             pt.to_string(),
-            field_values[5]
+            field_values[0]
         ))
     } else if field_index == 4 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v4 is NULL OR v4 = $2) AND
-                    (v5 is NULL OR v5 = $3)",
+                    (v4 is NULL OR v4 = COALESCE($2,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE($3,v5))",
             pt,
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1]
         ))
     } else if field_index == 3 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v3 is NULL OR v3 = $2) AND
-                    (v4 is NULL OR v4 = $3) AND
-                    (v5 is NULL OR v5 = $4)",
+                    (v3 is NULL OR v3 = COALESCE($2,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE($3,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE($4,v5))",
             pt,
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1],
+            field_values[2]
         ))
     } else if field_index == 2 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v2 is NULL OR v2 = $2) AND
-                    (v3 is NULL OR v3 = $3) AND
-                    (v4 is NULL OR v4 = $4) AND
-                    (v5 is NULL OR v5 = $5)",
+                    (v2 is NULL OR v2 = COALESCE($2,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE($3,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE($4,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE($5,v5))",
             pt,
+            field_values[0],
+            field_values[1],
             field_values[2],
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[3]
         ))
     } else if field_index == 1 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v1 is NULL OR v1 = $2) AND
-                    (v2 is NULL OR v2 = $3) AND
-                    (v3 is NULL OR v3 = $4) AND
-                    (v4 is NULL OR v4 = $5) AND
-                    (v5 is NULL OR v5 = $6)",
+                    (v1 is NULL OR v1 = COALESCE($2,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE($3,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE($4,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE($5,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE($6,v5))",
             pt,
+            field_values[0],
             field_values[1],
             field_values[2],
             field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[4]
         ))
     } else {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v0 is NULL OR v0 = $2) AND
-                    (v1 is NULL OR v1 = $3) AND
-                    (v2 is NULL OR v2 = $4) AND
-                    (v3 is NULL OR v3 = $5) AND
-                    (v4 is NULL OR v4 = $6) AND
-                    (v5 is NULL OR v5 = $7)",
+                    (v0 is NULL OR v0 = COALESCE($2,v0)) AND
+                    (v1 is NULL OR v1 = COALESCE($3,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE($4,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE($5,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE($6,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE($7,v5))",
             pt,
             field_values[0],
             field_values[1],
@@ -408,77 +408,77 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values);
+    let field_values = normalize_casbin_rule_option(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = $1 AND
-                    (v5 is NULL OR v5 = $2)",
+                    (v5 is NULL OR v5 = COALESCE(?2,v5))",
             pt,
-            field_values[5]
+            field_values[0]
         ))
     } else if field_index == 4 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
-                    (v4 is NULL OR v4 = ?2) AND
-                    (v5 is NULL OR v5 = ?3)",
+                    (v4 is NULL OR v4 = COALESCE(?2,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?3,v5))",
             pt,
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1]
         ))
     } else if field_index == 3 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
-                    (v3 is NULL OR v3 = ?2) AND
-                    (v4 is NULL OR v4 = ?3) AND
-                    (v5 is NULL OR v5 = ?4)",
+                    (v3 is NULL OR v3 = COALESCE(?2,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?3,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?4,v5))",
             pt,
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1],
+            field_values[2]
         ))
     } else if field_index == 2 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
-                    (v2 is NULL OR v2 = ?2) AND
-                    (v3 is NULL OR v3 = ?3) AND
-                    (v4 is NULL OR v4 = ?4) AND
-                    (v5 is NULL OR v5 = ?5)",
+                    (v2 is NULL OR v2 = COALESCE(?2,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?3,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?4,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?5,v5))",
             pt,
+            field_values[0],
+            field_values[1],
             field_values[2],
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[3]
         ))
     } else if field_index == 1 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
-                    (v1 is NULL OR v1 = ?2) AND
-                    (v2 is NULL OR v2 = ?3) AND
-                    (v3 is NULL OR v3 = ?4) AND
-                    (v4 is NULL OR v4 = ?5) AND
-                    (v5 is NULL OR v5 = ?6)",
+                    (v1 is NULL OR v1 = COALESCE(?2,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE(?3,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?4,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?5,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?6,v5))",
             pt,
+            field_values[0],
             field_values[1],
             field_values[2],
             field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[4]
         ))
     } else {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ?1 AND
-                    (v0 is NULL OR v0 = ?2) AND
-                    (v1 is NULL OR v1 = ?3) AND
-                    (v2 is NULL OR v2 = ?4) AND
-                    (v3 is NULL OR v3 = ?5) AND
-                    (v4 is NULL OR v4 = ?6) AND
-                    (v5 is NULL OR v5 = ?7)",
+                    (v0 is NULL OR v0 = COALESCE(?2,v0)) AND
+                    (v1 is NULL OR v1 = COALESCE(?3,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE(?4,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?5,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?6,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?7,v5))",
             pt,
             field_values[0],
             field_values[1],
@@ -503,77 +503,77 @@ pub async fn remove_filtered_policy(
     field_index: usize,
     field_values: Vec<String>,
 ) -> Result<bool> {
-    let field_values = normalize_casbin_rule(field_values);
+    let field_values = normalize_casbin_rule_option(field_values);
     let boxed_query = if field_index == 5 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt,
-            field_values[5]
+            field_values[0]
         ))
     } else if field_index == 4 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v4 is NULL OR v4 = ?) AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v4 is NULL OR v4 = COALESCE(?,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt.to_string(),
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1]
         ))
     } else if field_index == 3 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v3 is NULL OR v3 = ?) AND
-                    (v4 is NULL OR v4 = ?) AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v3 is NULL OR v3 = COALESCE(?,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt,
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[0],
+            field_values[1],
+            field_values[2]
         ))
     } else if field_index == 2 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v2 is NULL OR v2 = ?) AND
-                    (v3 is NULL OR v3 = ?) AND
-                    (v4 is NULL OR v4 = ?) AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v2 is NULL OR v2 = COALESCE(?,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt,
+            field_values[0],
+            field_values[1],
             field_values[2],
-            field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[3]
         ))
     } else if field_index == 1 {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v1 is NULL OR v1 = ?) AND
-                    (v2 is NULL OR v2 = ?) AND
-                    (v3 is NULL OR v3 = ?) AND
-                    (v4 is NULL OR v4 = ?) AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v1 is NULL OR v1 = COALESCE(?,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE(?,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt,
+            field_values[0],
             field_values[1],
             field_values[2],
             field_values[3],
-            field_values[4],
-            field_values[5]
+            field_values[4]
         ))
     } else {
         Box::new(sqlx::query!(
             "DELETE FROM casbin_rule WHERE
                     ptype = ? AND
-                    (v0 is NULL OR v0 = ?) AND
-                    (v1 is NULL OR v1 = ?) AND
-                    (v2 is NULL OR v2 = ?) AND
-                    (v3 is NULL OR v3 = ?) AND
-                    (v4 is NULL OR v4 = ?) AND
-                    (v5 is NULL OR v5 = ?)",
+                    (v0 is NULL OR v0 = COALESCE(?,v0)) AND
+                    (v1 is NULL OR v1 = COALESCE(?,v1)) AND
+                    (v2 is NULL OR v2 = COALESCE(?,v2)) AND
+                    (v3 is NULL OR v3 = COALESCE(?,v3)) AND
+                    (v4 is NULL OR v4 = COALESCE(?,v4)) AND
+                    (v5 is NULL OR v5 = COALESCE(?,v5))",
             pt,
             field_values[0],
             field_values[1],
@@ -1070,4 +1070,10 @@ pub(crate) async fn clear_policy(conn: &ConnectionPool) -> Result<()> {
 fn normalize_casbin_rule(mut rule: Vec<String>) -> Vec<String> {
     rule.resize(6, String::new());
     rule
+}
+
+fn normalize_casbin_rule_option(rule: Vec<String>) -> Vec<Option<String>> {
+    let mut rule_with_option = rule.iter().map(|x|Some(x.clone())).collect::<Vec<Option<String>>>();
+    rule_with_option.resize(6, None);
+    rule_with_option
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1073,7 +1073,10 @@ fn normalize_casbin_rule(mut rule: Vec<String>) -> Vec<String> {
 }
 
 fn normalize_casbin_rule_option(rule: Vec<String>) -> Vec<Option<String>> {
-    let mut rule_with_option = rule.iter().map(|x|Some(x.clone())).collect::<Vec<Option<String>>>();
+    let mut rule_with_option = rule
+        .iter()
+        .map(|x| Some(x.clone()))
+        .collect::<Vec<Option<String>>>();
     rule_with_option.resize(6, None);
     rule_with_option
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -565,7 +565,30 @@ mod tests {
                 to_owned(vec!["data2_admin", "domain1", "domain2"]),
             )
             .await
+            .unwrap());
+
+        // GitHub issue: https://github.com/casbin-rs/sqlx-adapter/issues/64
+        assert!(adapter
+            .add_policy(
+                "",
+                "g",
+                to_owned(vec!["carol", "data1_admin"]),
+            )
+            .await
             .is_ok());
+        assert!(adapter
+            .remove_filtered_policy(
+                "",
+                "g",
+                0,
+                to_owned(vec!["carol"]),
+            )
+            .await
+            .unwrap());
+        assert_eq!(
+            vec![String::new(); 0],
+            e.get_roles_for_user("carol", None)
+        );
 
         // shadow the previous enforcer
         let mut e = Enforcer::new(

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -569,26 +569,14 @@ mod tests {
 
         // GitHub issue: https://github.com/casbin-rs/sqlx-adapter/issues/64
         assert!(adapter
-            .add_policy(
-                "",
-                "g",
-                to_owned(vec!["carol", "data1_admin"]),
-            )
+            .add_policy("", "g", to_owned(vec!["carol", "data1_admin"]),)
             .await
             .is_ok());
         assert!(adapter
-            .remove_filtered_policy(
-                "",
-                "g",
-                0,
-                to_owned(vec!["carol"]),
-            )
+            .remove_filtered_policy("", "g", 0, to_owned(vec!["carol"]),)
             .await
             .unwrap());
-        assert_eq!(
-            vec![String::new(); 0],
-            e.get_roles_for_user("carol", None)
-        );
+        assert_eq!(vec![String::new(); 0], e.get_roles_for_user("carol", None));
 
         // shadow the previous enforcer
         let mut e = Enforcer::new(


### PR DESCRIPTION
Fix: https://github.com/casbin-rs/sqlx-adapter/issues/64 and add a testcase for it

The cause of this issue is bugs in `remove_filtered_policy()`, takes the [demo](https://github.com/bk138/casbinerr/blob/master/src/main.rs) provided in the issue for example:

`enforcer.delete_user("kurt")` will eventually call `adapter::remove_filtered_policy(&self.pool, pt, field_index, field_values)`, where `pt` is `"g"`, `field_index` is `0`, and `field_values` is `["kurt"]`. It will construct query string as below:

https://github.com/casbin-rs/sqlx-adapter/blob/443431de536c5b063e357927d7190df63162e5cd/src/actions.rs#L378-L394

`field_values` is resized to 6, and `field_values` now is `["kurt", "", "", "", "", ""]`, the generated query string is:
```sql
DELETE FROM casbin_rule WHERE 
ptype = "g" AND 
(v0 is NULL OR v0 = "kurt") AND 
(v1 is NULL OR v1 = "") AND 
(v2 is NULL OR v2 = "") AND 
(v3 is NULL OR v3 = "") AND 
(v4 is NULL OR v4 = "") AND 
(v5 is NULL OR v5 = "")
```

Records in database now are:
![image](https://user-images.githubusercontent.com/40566803/167300918-f794326f-0829-4aad-9ea1-e5860f926a8e.png)
Obviously, the record to be deleted doesn't match the query string, so the `g` policy is never deleted.

I fixed this bug by introduing a new function to normalize `field_values` to `Vec<Option<String>>` with size 6, and change query string to:
```sql
DELETE FROM casbin_rule WHERE
ptype = $1 AND
(v0 is NULL OR v0 = COALESCE($2,v0)) AND
(v1 is NULL OR v1 = COALESCE($3,v1)) AND
(v2 is NULL OR v2 = COALESCE($4,v2)) AND
(v3 is NULL OR v3 = COALESCE($5,v3)) AND
(v4 is NULL OR v4 = COALESCE($6,v4)) AND
(v5 is NULL OR v5 = COALESCE($7,v5))
```
Also, fix another bug that index of `field_values` in each query string not starting from 0. For example:
https://github.com/casbin-rs/sqlx-adapter/blob/443431de536c5b063e357927d7190df63162e5cd/src/actions.rs#L317-L325
`field_values[5]` should be replace with `field_values[0]`.