### PR TITLE
docs: update sqlx-adapter and enable `marcos` feature of tokio in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ ALTER TABLE casbin_rules RENAME TO casbin_rule;
 Add it to `Cargo.toml`
 
 ```rust
-sqlx-adapter = { version = "0.4.1, features = ["postgres"] }
-tokio = "1.1.1"
+sqlx-adapter = { version = "0.4.2, features = ["postgres"] }
+tokio = { version = "1.1.1", features = ["macros"] }
 ```
 
 **Warning**: `tokio v1.0` or later is supported from `sqlx-adapter v0.4.0`, we recommend that you upgrade the relevant components to ensure that they work properly. The last version that supports `tokio v0.2` is `sqlx-adapter v0.3.0` , you can choose according to your needs.


### PR DESCRIPTION
Update Install part of README to update sqlx-adapter version to 0.4.2 and enable `marcos` feature of tokio, otherwise build will fail with:
```shell
error[E0433]: failed to resolve: could not find `main` in `tokio`
 --> src/main.rs:5:10
  |
5 | #[tokio::main]
  |          ^^^^ could not find `main` in `tokio`
```