### PR TITLE
fix: features = ["mysql"] not working (#82)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ async-std = { version = "1.9.0", default-features = false, optional = true }
 actix-rt = { version = "2.2.0", default-features = false, optional = true }
 
 [features]
-default = ["postgres", "runtime-tokio-native-tls", "offline"]
+default = ["postgres", "offline"]
 
 #databases
-postgres = ["sqlx/postgres"]
-mysql = ["sqlx/mysql"]
-sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres", "runtime-tokio-native-tls"]
+mysql = ["sqlx/mysql", "runtime-tokio-native-tls"]
+sqlite = ["sqlx/sqlite", "runtime-tokio-native-tls"]
 
 # async runtime
 # async-std


### PR DESCRIPTION
fix: features = ["mysql"] not working (#82)

The problem with issue #82 is that when the `"mysql"` feature is enabled, the default feature is not disabled, resulting in both the `"mysql"` and `"postgres"` features being present, causing the code to throw an error of multiple variable definitions. After this modification is applied, when enabling the `"mysql"` feature, it is necessary to disable the default feature.

When using the `"mysql"` feature, add the following code to Cargo.toml.
``` Toml
sqlx-adapter = {version = "***", default-features = false, features = ["mysql"]}
tokio = { version = "1.1.1", features = ["macros"] }
```