### PR TITLE
feat: fix bug in remove_filtered_policy() and add test cases

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1075,7 +1075,10 @@ fn normalize_casbin_rule(mut rule: Vec<String>) -> Vec<String> {
 fn normalize_casbin_rule_option(rule: Vec<String>) -> Vec<Option<String>> {
     let mut rule_with_option = rule
         .iter()
-        .map(|x| Some(x.clone()))
+        .map(|x| match x.is_empty() {
+            true => None,
+            false => Some(x.clone()),
+        })
         .collect::<Vec<Option<String>>>();
     rule_with_option.resize(6, None);
     rule_with_option

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -251,7 +251,7 @@ impl Adapter for SqlxAdapter {
         field_index: usize,
         field_values: Vec<String>,
     ) -> Result<bool> {
-        if field_index <= 5 && !field_values.is_empty() && field_values.len() > field_index {
+        if field_index <= 5 && !field_values.is_empty() && field_values.len() + field_index <= 6 {
             adapter::remove_filtered_policy(&self.pool, pt, field_index, field_values).await
         } else {
             Ok(false)


### PR DESCRIPTION
I experienced issues using `remove_filtered_policy` where it would not work where I would know there would be valid matches.

For example:
```
p, admin, domain1, users, list
p, admin, domain1, users, update
```
Calling `remove_filtered_policy(1, vec!["domain1"])` or `remove_filtered_policy(1, vec!["domain1", "", "list"])` would return false.

I gave it a quick look and I found 2 small issues that I think are fixed by this PR.

1. `normalize_casbin_rule_option` leaves empty strings in, then the coalesce is not working
2. when `remove_filtered_policy` is checking for invalid input, it doesn't allow you to have field values length of more than the field index, which should be allowed, but the length of the field values should be capped by the offset the field index is setting

Hope I didn't miss anything or in haste made some wrong assumptions.