### PR TITLE
feat: Switch to dotenvy - a well maintained fork of the dotenv crate (unmaintained since 2019)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme= "README.md"
 casbin = { version = "2.1.0", default-features = false }
 sqlx = { version = "0.7", default-features = false, features = [ "macros" ] }
 async-trait = "0.1.51"
-dotenv = { version = "0.15.0", default-features = false }
+dotenvy = { version = "0.15.0", default-features = false }
 tokio = { version = "1.10.0", default-features = false, optional = true }
 async-std = { version = "1.9.0", default-features = false, optional = true }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use casbin::{error::AdapterError, Adapter, Error as CasbinError, Filter, Model, Result};
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,


### PR DESCRIPTION
This PR is to Switch to dotenvy - a well maintained fork of the dotenv crate (the latter unmaintained since 2019 almost 5 years ago)